### PR TITLE
feat(#4): AudioEngine（AudioContext 音声エンジン）を実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -1064,6 +1064,7 @@ class AudioEngine {
   constructor() {
     this._audioCtx = null;
     this._lastError = null;
+    this._isListenerRegistered = false;
     this._onVisibilityChange = this._handleVisibilityChange.bind(this);
   }
 
@@ -1073,10 +1074,11 @@ class AudioEngine {
    */
   async init() {
     if (!this._audioCtx) {
-      this._audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-      // removeEventListener is a no-op if not registered; guards against double-registration after destroy()
-      document.removeEventListener('visibilitychange', this._onVisibilityChange);
-      document.addEventListener('visibilitychange', this._onVisibilityChange);
+      this._audioCtx = new AudioContext();
+      if (!this._isListenerRegistered) {
+        document.addEventListener('visibilitychange', this._onVisibilityChange);
+        this._isListenerRegistered = true;
+      }
     }
 
     if (this._audioCtx.state === 'suspended') {
@@ -1105,7 +1107,7 @@ class AudioEngine {
    * @param {number} time - AudioContext.currentTime value to play at
    */
   playBeat(time) {
-    if (!this._audioCtx || this._audioCtx.state !== 'running') return;
+    if (!this.isReady()) return;
 
     const ctx = this._audioCtx;
     const osc = ctx.createOscillator();
@@ -1201,7 +1203,10 @@ class AudioEngine {
    * Only call on app teardown, NOT on mode switch.
    */
   destroy() {
-    document.removeEventListener('visibilitychange', this._onVisibilityChange);
+    if (this._isListenerRegistered) {
+      document.removeEventListener('visibilitychange', this._onVisibilityChange);
+      this._isListenerRegistered = false;
+    }
     if (this._audioCtx) {
       this._audioCtx.close().catch(e => {
         console.warn('[AudioEngine] Failed to close AudioContext:', e);


### PR DESCRIPTION
## 概要

AudioContext を使用した音声エンジン（AudioEngine）を実装。リズムドリルのビート音生成と管理を担当する共有コンポーネント。

Closes #4

## 変更内容

### AudioEngine クラス (`index.html`)
- **AudioContext 管理**: 遅延初期化（ユーザー操作で `audioCtx.resume()`）
- **ビート音再生**: `playBeat(time)` で指定した AudioContext.currentTime にビート音をスケジュール（矩形波 880Hz、50ms パルス）
- **バックグラウンド復帰**: `visibilitychange` で `document.hidden === false` 時に `audioCtx.state` 確認、`suspended` なら自動 `resume()` 試行
- **resume 失敗ハンドリング**: `_lastError` プロパティでエラー状態を保持、呼び出し側でフォールバック UI を制御可能
- **公開 API**: `init()`, `playBeat(time)`, `resume()`, `suspend()`, `isReady()`, `state`, `currentTime`, `lastError`, `destroy()`

### App 統合
- `AudioEngine` インスタンスを App 初期化に追加
- `window.EFTTrainer` に `audioEngine` を公開

### 自己テスト関数
- `EFTTrainer.runAudioEngineTests()` でコンソールから実行可能
- 初期状態、init/suspend/resume、playBeat、destroy の各 API をテスト

## 変更ファイル

| ファイル | 状態 | 変更内容 |
|---------|------|---------|
| `index.html` | Modified | AudioEngine クラス追加、App 統合、自己テスト関数追加 |

## チェックリスト

- [x] 設計ドキュメントの仕様に準拠
- [x] 公開 API が設計通り実装済み
- [x] バックグラウンド復帰処理を実装
- [x] resume 失敗時のエラーハンドリングを実装
- [x] 自己テスト関数を追加
- [x] Issue チェックリスト全項目完了

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした — 単一 HTML ファイルプロジェクト）

## 関連

- 親 Issue: #1 - EFT リーン操作トレーニングアプリの実装
- 依存: #2 - HTML/CSS 基盤 + コアシステム
