### PR TITLE
feat(settings): Q/Eリーン方向の設定切替機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,11 @@ html, body {
   border-color: var(--accent-turquoise);
 }
 
+.toggle-btn:focus-visible {
+  outline: 2px solid var(--accent-turquoise);
+  outline-offset: 2px;
+}
+
 #mode-select {
   padding: 4px 8px;
   font-size: 11px;
@@ -956,10 +961,10 @@ html, body {
         <button class="toggle-btn active" data-lean-mode="hold">Hold</button>
         <button class="toggle-btn" data-lean-mode="toggle">Toggle</button>
       </div>
-      <div class="toggle-group">
+      <div class="toggle-group" role="group" aria-label="リーン方向">
         <span>Layout:</span>
-        <button class="toggle-btn active" data-lean-dir="reversed">Q=右 E=左</button>
-        <button class="toggle-btn" data-lean-dir="standard">EFT標準</button>
+        <button class="toggle-btn active" data-lean-dir="reversed" aria-pressed="true">Q=右 E=左</button>
+        <button class="toggle-btn" data-lean-dir="standard" aria-pressed="false">EFT標準</button>
       </div>
       <select id="mode-select">
         <option value="free">Free Practice</option>
@@ -992,9 +997,9 @@ html, body {
       <!-- Key Indicators -->
       <div id="key-indicators">
         <div class="key-row">
-          <div class="key lean-left" data-key="KeyQ">Q</div>
+          <div class="key" data-key="KeyQ">Q</div>
           <div class="key" data-key="KeyW">W</div>
-          <div class="key lean-right" data-key="KeyE">E</div>
+          <div class="key" data-key="KeyE">E</div>
         </div>
         <div class="key-row">
           <div class="key" data-key="KeyA">A</div>
@@ -1210,6 +1215,17 @@ class InputManager {
       ? { KeyQ: 'left', KeyE: 'right' }
       : { KeyQ: 'right', KeyE: 'left' };
     this.resetState();
+    this._updateKeyIndicatorClasses();
+  }
+
+  _updateKeyIndicatorClasses() {
+    const qEl = document.querySelector('.key[data-key="KeyQ"]');
+    const eEl = document.querySelector('.key[data-key="KeyE"]');
+    if (!qEl || !eEl) return;
+    qEl.classList.remove('lean-left', 'lean-right');
+    eEl.classList.remove('lean-left', 'lean-right');
+    qEl.classList.add('lean-' + this._keyToLean.KeyQ);
+    eEl.classList.add('lean-' + this._keyToLean.KeyE);
   }
 
   getLeanKeyForDirection(direction) {
@@ -3485,6 +3501,7 @@ class ComboDrillMode extends ModeLifecycle {
   }
 
   _renderDemoSteps(container, combo) {
+    const resolvedSteps = combo.steps.map(s => this._resolveStepKeys(s.keys));
     for (let i = 0; i < combo.steps.length; i++) {
       if (i > 0) {
         const arrow = document.createElement('span');
@@ -3503,7 +3520,7 @@ class ComboDrillMode extends ModeLifecycle {
 
       const keysSpan = document.createElement('span');
       keysSpan.className = 'step-keys';
-      keysSpan.textContent = this._resolveStepKeys(step.keys).map(k => this._keyNames[k] || k).join('+');
+      keysSpan.textContent = resolvedSteps[i].map(k => this._keyNames[k] || k).join('+');
 
       stepEl.appendChild(actionSpan);
       stepEl.appendChild(keysSpan);
@@ -4631,14 +4648,18 @@ class PlaceholderMode extends ModeLifecycle {
       input.setLeanDirection(isStandard);
       leanDirBtns.forEach(b => {
         const bIsStandard = b.dataset.leanDir === 'standard';
-        b.classList.toggle('active', bIsStandard === isStandard);
+        const isActive = bIsStandard === isStandard;
+        b.classList.toggle('active', isActive);
+        b.setAttribute('aria-pressed', String(isActive));
       });
       appData.settings.useEftStandard = isStandard;
       storage.save(appData);
     });
 
     const isStandard = btn.dataset.leanDir === 'standard';
-    btn.classList.toggle('active', isStandard === !!appData.settings.useEftStandard);
+    const isActive = isStandard === !!appData.settings.useEftStandard;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', String(isActive));
   });
 
   // --- Register Modes ---


### PR DESCRIPTION
## 概要

Q/E キーのリーン方向を設定で切替可能にする機能を実装。

デフォルトで Q=右リーン・E=左リーン（EFT 標準の逆）とし、設定パネルのトグルで EFT 標準配置（Q=左・E=右）に切替可能。

Closes #26

## 変更内容

### InputManager
- `_keyToLean` マッピングオブジェクトで Q/E→リーン方向を動的解決
- `setLeanDirection(useEftStandard)` メソッド追加
- `getLeanKeyForDirection(direction)` メソッド追加（他モジュールからのキー逆引き用）
- `_updateLeanState` をマッピングベースにリファクタリング

### Storage
- `schemaVersion` を 1→2 に更新
- `settings.useEftStandard: false` をデフォルトに追加
- v1→v2 マイグレーション関数を実装

### 設定パネル UI
- 「Layout」トグルグループを追加（Q=右 E=左 / EFT標準）
- 切替時に即座反映（モード再起動不要）
- 設定値を Storage に永続化

### ComboDrillMode
- `_resolveKey()` / `_resolveStepKeys()` でコンボステップのキーを動的に解決
- UI 表示（ステップ指示・デモ）にも解決済みキーを使用

### RhythmDrillMode
- ビート表示のキーラベルを `getLeanKeyForDirection()` で動的解決

### テスト
- InputManager: reversed/standard 両方向のテストケース追加（Hold/Toggle）
- `getLeanKeyForDirection` のテストケース追加
- ComboDrillMode: `_resolveKey` / `_resolveStepKeys` のテストケース追加
- Storage: v1→v2 マイグレーションテスト、schemaVersion 更新

## 変更ファイル

| ファイル | 状態 |
|---------|------|
| index.html | Modified |

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）
