### PR TITLE
feat(#28): WASD/QEのキー表示を矢印・方向記号に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
   --panel-border: rgba(15, 52, 96, 0.6);
   --bg-darker: #111;
   --accent-yellow: #f0a500;
+  --font-symbols: 'Segoe UI Symbol', 'Apple Symbols', 'Noto Sans Symbols 2', sans-serif;
 }
 
 html, body {
@@ -88,7 +89,7 @@ html, body {
 .toggle-btn {
   padding: 4px 10px;
   font-size: 11px;
-  font-family: inherit;
+  font-family: var(--font-symbols);
   background: var(--key-bg);
   color: var(--text-secondary);
   border: 1px solid var(--key-border);
@@ -205,7 +206,7 @@ html, body {
   color: var(--text-secondary);
   transition: all 0.08s;
   text-shadow: none;
-  font-family: 'Segoe UI Symbol', 'Apple Symbols', 'Noto Sans Symbols 2', sans-serif;
+  font-family: var(--font-symbols);
 }
 
 .key.active {
@@ -335,7 +336,7 @@ html, body {
   height: 48px;
   font-size: 22px;
   font-weight: bold;
-  font-family: inherit;
+  font-family: var(--font-symbols);
   background: var(--key-bg);
   border: 2px solid var(--accent-turquoise);
   border-radius: 6px;
@@ -487,6 +488,7 @@ html, body {
   border: 1px solid var(--panel-border);
   border-radius: 4px;
   font-size: 11px;
+  font-family: var(--font-symbols);
   color: var(--text-muted);
   display: flex;
   align-items: center;
@@ -724,6 +726,7 @@ html, body {
   justify-content: center;
   font-size: 32px;
   font-weight: bold;
+  font-family: var(--font-symbols);
   color: var(--accent-turquoise);
   transition: all 0.15s;
 }
@@ -836,6 +839,7 @@ html, body {
 .combo-demo-step {
   display: inline-flex; align-items: center; gap: 3px;
   padding: 3px 6px; border-radius: 3px; font-size: 11px;
+  font-family: var(--font-symbols);
   background: var(--bg-secondary); color: var(--text-secondary);
   border: 1px solid transparent; transition: all 0.2s;
 }
@@ -1235,8 +1239,7 @@ class InputManager {
   }
 
   getKeySymbol(keyCode) {
-    const moveSymbols = { KeyW: '↑', KeyA: '←', KeyS: '↓', KeyD: '→' };
-    if (moveSymbols[keyCode]) return moveSymbols[keyCode];
+    if (InputManager._MOVE_SYMBOLS[keyCode]) return InputManager._MOVE_SYMBOLS[keyCode];
     if (keyCode === 'KeyQ') return this._keyToLean.KeyQ === 'right' ? '↷' : '↶';
     if (keyCode === 'KeyE') return this._keyToLean.KeyE === 'right' ? '↷' : '↶';
     return keyCode;
@@ -1255,6 +1258,7 @@ class InputManager {
     document.removeEventListener('visibilitychange', this._onVisibilityChange);
   }
 }
+InputManager._MOVE_SYMBOLS = { KeyW: '↑', KeyA: '←', KeyS: '↓', KeyD: '→' };
 
 // ============================================================
 // Storage — localStorage with schema versioning & fallback


### PR DESCRIPTION
## 概要

WASD / QE のキー表示を、キーボードの文字ラベルから矢印・方向記号に変更。
操作の方向性が直感的に伝わるようにする。

Closes #28

## 変更内容

- **InputManager**: `getKeySymbol(keyCode)` メソッドを追加。キーコードから方向記号（↑←↓→↶↷）を返す
- **キーインジケータ**: HTML テキストを Q/W/E/A/S/D → ↶/↑/↷/←/↓/→ に変更
- **`_updateKeyIndicatorClasses()`**: リーン方向設定に応じて Q/E のカーブ矢印テキストも動的に切替
- **`updateLeanDisplay()`**: `◄ LEFT` → `↶ リーン`、`RIGHT ►` → `リーン ↷` に変更
- **ウォームアップガイド**: ステップラベルを矢印記号に変更（Q/E は動的取得）
- **ReactionDrillMode / ComboDrillMode**: 静的 `_keyNames` / `KEY_NAMES` を廃止し、`InputManager.getKeySymbol()` による動的取得に統一
- **RhythmDrillMode**: パターンプレビュー・ドリル表示を矢印記号に変更
- **セルフテスト**: `getKeySymbol()` のテストを追加（reversed / standard 両方向）

## 記号マッピング

| キー | 記号 | 操作 |
|------|------|------|
| W | ↑ | 前進 |
| A | ← | 左移動 |
| S | ↓ | 後退 |
| D | → | 右移動 |
| Q | ↶ or ↷ | リーン（方向設定依存） |
| E | ↶ or ↷ | リーン（方向設定依存） |

## テスト計画

- [x] `getKeySymbol()` が WASD に対して固定の方向矢印を返す
- [x] `getKeySymbol()` が Q/E に対してリーン方向設定に応じたカーブ矢印を返す
- [x] リーン方向切替時に Q/E のカーブ矢印が連動して変わる
- [x] セルフテスト（`EFTTrainer.runTests()`）に `getKeySymbol` テストを追加

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
